### PR TITLE
Retrying tasks that failed.

### DIFF
--- a/karamel-core/src/main/java/se/kth/karamel/backend/command/CommandService.java
+++ b/karamel-core/src/main/java/se/kth/karamel/backend/command/CommandService.java
@@ -12,10 +12,9 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.apache.log4j.Logger;
 import se.kth.karamel.backend.ClusterDefinitionService;
 import se.kth.karamel.backend.ClusterManager;
 import se.kth.karamel.backend.ClusterService;
@@ -47,6 +46,7 @@ import se.kth.karamel.common.exception.KaramelException;
  */
 public class CommandService {
 
+  private static final Logger logger = Logger.getLogger(CommandService.class);
   private static String chosenCluster = null;
   private static String autoselectedCluster = null;
   private static String chosenMachine = "";
@@ -264,8 +264,7 @@ public class CommandService {
                   Thread.sleep(200);
 
                 } catch (InterruptedException ex) {
-                  Logger.getLogger(CommandService.class
-                      .getName()).log(Level.SEVERE, null, ex);
+                  logger.error("", ex);
                 }
                 result = shell.readStreams();
                 renderer = CommandResponse.Renderer.SSH;
@@ -311,8 +310,7 @@ public class CommandService {
                 Thread.sleep(100);
 
               } catch (InterruptedException ex) {
-                Logger.getLogger(CommandService.class
-                    .getName()).log(Level.SEVERE, null, ex);
+                logger.error("", ex);
               }
               result = shell.readStreams();
               renderer = CommandResponse.Renderer.SSH;
@@ -359,8 +357,7 @@ public class CommandService {
 
             @Override
             public void submitTask(Task task) throws KaramelException {
-              Logger.getLogger(CommandService.class.getName()).log(Level.FINEST,
-                  " Received request to process a command with info: {0}", task.uniqueId());
+              logger.info(" Received request to process a command with info: " + task.uniqueId());
               task.succeed();
             }
 
@@ -449,6 +446,7 @@ public class CommandService {
           clusterService.startCluster(json);
           successMessage = String.format("cluster %s launched successfully..", clusterName);
           nextCmd = "status";
+          addActiveClusterMenus(response);
         }
       }
 
@@ -474,6 +472,7 @@ public class CommandService {
           if (!taskFound) {
             throw new KaramelException("Opps, task was not found, make sure cluster is chosen first");
           }
+          addActiveClusterMenus(response);
         } else {
           throw new KaramelException("no cluster has been chosen yet!!");
         }

--- a/karamel-core/src/main/java/se/kth/karamel/backend/machines/MachineInterface.java
+++ b/karamel-core/src/main/java/se/kth/karamel/backend/machines/MachineInterface.java
@@ -1,0 +1,19 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package se.kth.karamel.backend.machines;
+
+import java.io.IOException;
+import se.kth.karamel.common.exception.KaramelException;
+
+/**
+ *
+ * @author kamal
+ */
+public interface MachineInterface {
+
+  public void downloadRemoteFile(String remoteFilePath, String localFilePath, boolean overwrite) throws KaramelException, IOException;
+
+}

--- a/karamel-core/src/main/java/se/kth/karamel/backend/machines/SshShell.java
+++ b/karamel-core/src/main/java/se/kth/karamel/backend/machines/SshShell.java
@@ -44,7 +44,11 @@ public class SshShell {
   private StringBuilder builder = new StringBuilder();
   private Thread streamReader;
 
-  public SshShell(String privateKey, String publicKey, String ipAddress, String sshUser, 
+  public SshShell(String privateKey, String publicKey, String ipAddress, String sshUser, int sshPort) {
+    this(privateKey, publicKey, ipAddress, sshUser, null, sshPort);
+  }
+
+  public SshShell(String privateKey, String publicKey, String ipAddress, String sshUser,
       String passphrase, int sshPort) {
     this.privateKey = privateKey;
     this.publicKey = publicKey;
@@ -54,7 +58,6 @@ public class SshShell {
     this.sshPort = sshPort;
   }
 
-  
   private PasswordFinder getPasswordFinder() {
     return new PasswordFinder() {
 
@@ -68,7 +71,8 @@ public class SshShell {
         return false;
       }
     };
-  }  
+  }
+
   public void connect() throws KaramelException {
     try {
       if (isConnected()) {

--- a/karamel-core/src/main/java/se/kth/karamel/backend/running/model/tasks/InstallBerkshelfTask.java
+++ b/karamel-core/src/main/java/se/kth/karamel/backend/running/model/tasks/InstallBerkshelfTask.java
@@ -10,6 +10,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import se.kth.karamel.backend.converter.ShellCommandBuilder;
+import se.kth.karamel.backend.machines.MachineInterface;
 import se.kth.karamel.backend.machines.TaskSubmitter;
 import se.kth.karamel.backend.running.model.MachineRuntime;
 import se.kth.karamel.common.Settings;

--- a/karamel-core/src/main/java/se/kth/karamel/backend/running/model/tasks/MakeSoloRbTask.java
+++ b/karamel-core/src/main/java/se/kth/karamel/backend/running/model/tasks/MakeSoloRbTask.java
@@ -10,6 +10,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import se.kth.karamel.backend.converter.ShellCommandBuilder;
+import se.kth.karamel.backend.machines.MachineInterface;
 import se.kth.karamel.backend.machines.TaskSubmitter;
 import se.kth.karamel.backend.running.model.MachineRuntime;
 import se.kth.karamel.common.Settings;

--- a/karamel-core/src/main/java/se/kth/karamel/backend/running/model/tasks/Task.java
+++ b/karamel-core/src/main/java/se/kth/karamel/backend/running/model/tasks/Task.java
@@ -11,6 +11,7 @@ import java.util.UUID;
 import org.apache.log4j.Logger;
 import se.kth.karamel.backend.dag.DagTask;
 import se.kth.karamel.backend.dag.DagTaskCallback;
+import se.kth.karamel.backend.machines.MachineInterface;
 import se.kth.karamel.backend.machines.TaskSubmitter;
 import se.kth.karamel.backend.running.model.Failure;
 import se.kth.karamel.backend.running.model.MachineRuntime;
@@ -68,7 +69,6 @@ public abstract class Task implements DagTask, TaskCallback {
     return String.format("\"name\": \"%s\", \"machine\": \"%s\"", name, machineId);
   }
 
-  
   @Override
   public String toString() {
     return name + " on " + machineId;
@@ -137,4 +137,7 @@ public abstract class Task implements DagTask, TaskCallback {
     dagCallback.failed(reason);
   }
 
+  public void collectResults(MachineInterface sshMachine) throws KaramelException {
+    //override it in the subclasses if needed
+  }
 }

--- a/karamel-core/src/main/java/se/kth/karamel/common/Settings.java
+++ b/karamel-core/src/main/java/se/kth/karamel/common/Settings.java
@@ -27,6 +27,7 @@ public class Settings {
   //read
   public static final String ATTR_DELIMITER = "/";
   public static final String COOOKBOOK_DELIMITER = "::";
+  public static final String COOOKBOOK_FS_PATH_DELIMITER = "__";
   public static final String INSTALL_RECIPE = "install";
   public final static String CHEF_PRIVATE_IPS = "private_ips";
   public final static String CHEF_PUBLIC_IPS = "public_ips";
@@ -116,11 +117,12 @@ public class Settings {
   public static final String KARAMEL_CONF_NAME = "conf";
   public static final String SSH_FOLDER_NAME = ".ssh";
   public static final String TMP_FOLDER_NAME = "tmp";
-  public static final String SYSTEM_TMP_FOLDER_NAME = "/tmp";
+  public static final String SYSTEM_TMP_FOLDER_PATH = "/" + TMP_FOLDER_NAME;
   public static final String KARAMEL_SSH_PATH = KARAMEL_ROOT_PATH + File.separator + SSH_FOLDER_NAME;
-  public static final String KARAMEL_TMP_PATH = KARAMEL_ROOT_PATH + File.separator + TMP_FOLDER_NAME;    
+  public static final String KARAMEL_TMP_PATH = KARAMEL_ROOT_PATH + File.separator + TMP_FOLDER_NAME;
   public static final String SSH_PUBKEY_FILENAME = "ida_rsa.pub";
   public static final String SSH_PRIVKEY_FILENAME = "ida_rsa";
+  public static final String RECIPE_RESULT_POSFIX = "__out.json";
 
   public static String CLUSTER_LOG_FOLDER(String clusterName) {
     return CLUSTER_ROOT_PATH(clusterName) + File.separator + "logs";
@@ -154,6 +156,36 @@ public class Settings {
     }
   }
 
+  public static String RECIPE_RESULT_REMOTE_PATH(String recipeName) {
+    String recName;
+    if (!recipeName.contains(COOOKBOOK_DELIMITER)) {
+      recName = recipeName + COOOKBOOK_DELIMITER + "default";
+    } else {
+      recName = recipeName;
+    }
+
+    return Settings.SYSTEM_TMP_FOLDER_PATH + File.separator + recName.replace(COOOKBOOK_DELIMITER, COOOKBOOK_FS_PATH_DELIMITER) + RECIPE_RESULT_POSFIX;
+  }
+
+  public static String CLUSTER_TEMP_FOLDER(String clusterName) {
+    return CLUSTER_ROOT_PATH(clusterName) + File.separator + "tmp";
+  }
+
+  public static String MACHINE_TEMP_FOLDER(String clusterName, String machineIp) {
+    return CLUSTER_TEMP_FOLDER(clusterName) + File.separator + machineIp;
+  }
+
+  public static String RECIPE_RESULT_LOCAL_PATH(String recipeName, String clusterName, String machineIp) {
+    String recName;
+    if (!recipeName.contains(COOOKBOOK_DELIMITER)) {
+      recName = recipeName + COOOKBOOK_DELIMITER + "default";
+    } else {
+      recName = recipeName;
+    }
+    return MACHINE_TEMP_FOLDER(clusterName, machineIp) + File.separator
+        + recName.replace(COOOKBOOK_DELIMITER, COOOKBOOK_FS_PATH_DELIMITER) + RECIPE_RESULT_POSFIX;
+  }
+
   public static final int EC2_RETRY_INTERVAL = 5 * 1000;
   public static final int EC2_RETRY_MAX = 100;
   public static final List<String> EC2_DEFAULT_PORTS = Arrays.asList(new String[]{"22"});
@@ -161,6 +193,11 @@ public class Settings {
 
   public static final int MACHINES_TASKQUEUE_SIZE = 100;
 
+  public static final int SSH_CMD_RETRY_NUM = 2;
+  public static final int SSH_CMD_RETRY_INTERVALS = 3000; //ms
+  public static final float SSH_CMD_RETRY_SCALE = 1.5f;
+  public static final int SSH_CMD_LONGEST = 24 * 60; // minutes
+  
   //Git cookbook metadata 
   public static final String COOKBOOK_DEFAULTRB_REL_URL = "/attributes/default.rb";
   public static final String COOKBOOK_METADATARB_REL_URL = "/metadata.rb";

--- a/karamel-core/src/test/java/e2e/se/kth/karamel/client/api/KaramelApiTest.java
+++ b/karamel-core/src/test/java/e2e/se/kth/karamel/client/api/KaramelApiTest.java
@@ -163,11 +163,33 @@ public class KaramelApiTest {
       Thread.currentThread().sleep(60000);
     }
   }
-
-//  @Test
+  
+//   @Test
   public void testStatus() throws KaramelException, IOException, InterruptedException {
     String clusterName = "flink";
     String ymlString = Resources.toString(Resources.getResource("se/kth/hop/model/flink.yml"), Charsets.UTF_8);
+    String json = api.yamlToJson(ymlString);
+    SshKeyPair sshKeys = api.loadSshKeysIfExist("");
+    if (sshKeys == null) {
+      sshKeys = api.generateSshKeysAndUpdateConf(clusterName);
+    }
+    api.registerSshKeys(sshKeys);
+    Ec2Credentials credentials = api.loadEc2CredentialsIfExist();
+    api.updateEc2CredentialsIfValid(credentials);
+    api.startCluster(json);
+    long ms1 = System.currentTimeMillis();
+    int mins = 0;
+    while (ms1 + 24 * 60 * 60 * 1000 > System.currentTimeMillis()) {
+      mins++;
+      System.out.println(api.processCommand("status").getResult());
+      Thread.currentThread().sleep(60000);
+    }
+  }
+
+  @Test
+  public void testReturnResults() throws KaramelException, IOException, InterruptedException {
+    String clusterName = "ndb";
+    String ymlString = Resources.toString(Resources.getResource("se/kth/hop/model/ndb.yml"), Charsets.UTF_8);
     String json = api.yamlToJson(ymlString);
     SshKeyPair sshKeys = api.loadSshKeysIfExist("");
     if (sshKeys == null) {

--- a/karamel-core/src/test/java/se/kth/karamel/backend/machines/SshShellTest.java
+++ b/karamel-core/src/test/java/se/kth/karamel/backend/machines/SshShellTest.java
@@ -52,7 +52,7 @@ public class SshShellTest {
         + "-----END RSA PRIVATE KEY-----";
 
     String publicKey = "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key";
-    SshShell shell = new SshShell(privateKey, publicKey, "192.168.33.10", "vagrant", null, 22);
+    SshShell shell = new SshShell(privateKey, publicKey, "192.168.33.10", "vagrant", 22);
     FileOutputStream fos = new FileOutputStream(new File("/home/kamal/output1"));
 
     shell.connect();

--- a/karamel-core/src/test/java/se/kth/karamel/common/SshKeyServiceTest.java
+++ b/karamel-core/src/test/java/se/kth/karamel/common/SshKeyServiceTest.java
@@ -6,7 +6,6 @@
 package se.kth.karamel.common;
 
 import org.junit.Ignore;
-import org.junit.Test;
 
 /**
  *

--- a/karamel-core/src/test/resources/se/kth/hop/model/ndb.yml
+++ b/karamel-core/src/test/resources/se/kth/hop/model/ndb.yml
@@ -1,0 +1,18 @@
+name: ndb
+ec2:
+    type: m3.medium
+    region: eu-west-1
+
+cookbooks:                                                                      
+  ndb:
+    github: "hopshadoop/ndb-chef"
+    branch: "master"
+    
+groups: 
+  nodes:
+    size: 1 
+    recipes: 
+        - ndb::mgmd
+        - ndb::ndbd
+        - ndb::mysqld
+        - ndb::memcached


### PR DESCRIPTION
This is a simple fix, don't see why it won't work.
We set a retry count and retry failed tasks that number of times.
If ssh connections break, MachinesMonitor will ping them, restart them and they can pull tasks again. If a task taken from the queue fails, the task is stubbornly retried.

We should move retryCount, timeBetweenRetries, and scaleTimeBetweenRetries to the config file - @kamalhakim.