### PR TITLE
 * Updated jclouds to 2.1.0 

### DIFF
--- a/karamel-common/pom.xml
+++ b/karamel-common/pom.xml
@@ -58,7 +58,7 @@
       <version>${jclouds.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.jclouds.labs</groupId>
+      <groupId>org.apache.jclouds.provider</groupId>
       <artifactId>google-compute-engine</artifactId>
       <version>${jclouds.version}</version>
     </dependency>

--- a/karamel-common/src/main/java/se/kth/karamel/common/clusterdef/Gce.java
+++ b/karamel-common/src/main/java/se/kth/karamel/common/clusterdef/Gce.java
@@ -11,11 +11,11 @@ import se.kth.karamel.common.exception.ValidationException;
 public class Gce extends Provider {
 
   private String type;
-  // TODO: IP range to give to VMs.
-//  private String network;
   private String zone;
   private String image;
-
+  private String vpc;
+  private Long diskSize;
+  
   /**
    * Machine type.
    *
@@ -42,19 +42,19 @@ public class Gce extends Provider {
     this.zone = zone;
   }
 
-//  /**
-//   * @return the network
-//   */
-//  public String getNetwork() {
-//    return network;
-//  }
-//
-//  /**
-//   * @param network the network to set
-//   */
-//  public void setNetwork(String network) {
-//    this.network = network;
-//  }
+  /**
+   * @return the vpc network
+   */
+  public String getVpc() {
+    return vpc;
+  }
+
+  /**
+   * @param vpc the vpc network to set
+   */
+  public void setVpc(String vpc) {
+    this.vpc = vpc;
+  }
   /**
    * Image name
    *
@@ -72,16 +72,32 @@ public class Gce extends Provider {
   public void setImage(String image) {
     this.image = image;
   }
-
+  
+  /**
+   * Size for the boot disk in GB
+   * @return the diskSize in GB
+   */
+  public Long getDiskSize() {
+    return diskSize;
+  }
+  
+  /**
+   * Boot Disksize in GB
+   * @param diskSize
+   */
+  public void setDiskSize(Long diskSize) {
+    this.diskSize = diskSize;
+  }
+  
   @Override
   public Gce cloneMe() {
     Gce gce = new Gce();
     gce.setUsername(this.getUsername());
     gce.setImage(image);
     gce.setType(type);
-//    gce.setNetwork(network);
+    gce.setVpc(vpc);
     gce.setZone(zone);
-
+    gce.setDiskSize(diskSize);
     return gce;
   }
 
@@ -102,6 +118,12 @@ public class Gce extends Provider {
       if (clone.getType() == null) {
         clone.setType(parentGce.getType());
       }
+      if(clone.getVpc() == null){
+        clone.setVpc(parentGce.getVpc());
+      }
+      if(clone.getDiskSize() == null){
+        clone.setDiskSize(parentGce.getDiskSize());
+      }
     }
     return clone;
   }
@@ -121,11 +143,28 @@ public class Gce extends Provider {
     if (clone.getType() == null) {
       clone.setType(GceSettings.DEFAULT_MACHINE_TYPE);
     }
+    if(clone.getVpc() == null){
+      clone.setVpc(GceSettings.DEFAULT_NETWORK_NAME);
+    }
+    if(clone.getDiskSize() == null){
+      clone.setDiskSize(GceSettings.DEFAULT_DISKSIZE_IN_GB);
+    }
     return clone;
   }
 
   @Override
   public void validate() throws ValidationException {
     // Currently nothing to validate. But IP range can be validate here.
+  }
+  
+  @Override
+  public String toString() {
+    return "Gce{" +
+        "type='" + type + '\'' +
+        ", zone='" + zone + '\'' +
+        ", image='" + image + '\'' +
+        ", vpc='" + vpc + '\'' +
+        ", diskSize=" + diskSize +
+        '}';
   }
 }

--- a/karamel-common/src/main/java/se/kth/karamel/common/util/GceSettings.java
+++ b/karamel-common/src/main/java/se/kth/karamel/common/util/GceSettings.java
@@ -15,7 +15,8 @@ public class GceSettings {
   public static final String DEFAULT_IMAGE = "ubuntu-1404-trusty-v20150316";
   public static final String DEFAULT_ZONE = "europe-west1-b";
   public static final String DEFAULT_MACHINE_TYPE = MachineType.n1_standard_1.toString();
-
+  public static final Long DEFAULT_DISKSIZE_IN_GB = 15l;
+  
   public enum MachineType {
 
     n1_standard_1("n1-standard-1"),

--- a/karamel-core/pom.xml
+++ b/karamel-core/pom.xml
@@ -79,7 +79,7 @@
       <version>${jclouds.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.jclouds.labs</groupId>
+      <groupId>org.apache.jclouds.provider</groupId>
       <artifactId>google-compute-engine</artifactId>
       <version>${jclouds.version}</version>
     </dependency>

--- a/karamel-core/src/test/java/se/kth/karamel/backend/machines/RudimentaryPTY.java
+++ b/karamel-core/src/test/java/se/kth/karamel/backend/machines/RudimentaryPTY.java
@@ -7,6 +7,7 @@ package se.kth.karamel.backend.machines;
 
 import java.io.BufferedReader;
 import net.schmizz.sshj.SSHClient;
+import net.schmizz.sshj.common.LoggerFactory;
 import net.schmizz.sshj.common.StreamCopier;
 import net.schmizz.sshj.connection.channel.direct.Session;
 import net.schmizz.sshj.connection.channel.direct.Session.Shell;
@@ -69,18 +70,18 @@ class RudimentaryPTY {
 
         final Shell shell = session.startShell();
 
-        new StreamCopier(shell.getInputStream(), System.out)
+        new StreamCopier(shell.getInputStream(), System.out, LoggerFactory.DEFAULT)
             .bufSize(shell.getLocalMaxPacketSize())
             .spawn("stdout");
 
-        new StreamCopier(shell.getErrorStream(), System.err)
+        new StreamCopier(shell.getErrorStream(), System.err, LoggerFactory.DEFAULT)
             .bufSize(shell.getLocalMaxPacketSize())
             .spawn("stderr");
 
         // Now make System.in act as stdin. To exit, hit Ctrl+D (since that results in an EOF on System.in)
         // This is kinda messy because java only allows console input after you hit return
         // But this is just an example... a GUI app could implement a proper PTY
-        new StreamCopier(System.in, shell.getOutputStream())
+        new StreamCopier(System.in, shell.getOutputStream(), LoggerFactory.DEFAULT)
             .bufSize(shell.getRemoteMaxPacketSize())
             .copy();
 

--- a/karamel-ui/src/main/resources/assets/karamel/board/datamodel.js
+++ b/karamel-ui/src/main/resources/assets/karamel/board/datamodel.js
@@ -388,12 +388,16 @@ function Gce() {
   this.username = null;
   this.image = null;
   this.jsonKeyPath = null;
+  this.vpc = null;
+  this.diskSize = null;
 
   this.load = function(other) {
     this.type = other.type || null;
     this.zone = other.zone || null;
     this.username = other.username || null;
     this.image = other.image || null;
+    this.vpc = other.vpc || null;
+    this.diskSize = other.diskSize || null;
   };
 
   this.copy = function(other) {
@@ -401,6 +405,8 @@ function Gce() {
     this.zone = other.zone || null;
     this.username = other.username || null;
     this.image = other.image || null;
+    this.vpc = other.vpc || null;
+    this.diskSize = other.diskSize || null;
   };
 
   this.addAccountDetails = function(other) {
@@ -832,11 +838,15 @@ function toCoreApiFormat(uiCluster) {
     this.zone = null;
     this.username = null;
     this.image = null;
+    this.vpc = null;
+    this.diskSize = null;
     this.load = function(other) {
       this.type = other.type || null;
       this.zone = other.zone || null;
       this.username = other.username || null;
       this.image = other.image || null;
+      this.vpc = other.vpc || null;
+      this.diskSize = other.diskSize || null;
     }
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jclouds.version>1.9.3</jclouds.version>
+    <jclouds.version>2.1.0</jclouds.version>
     <java.compiler.version>1.8</java.compiler.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>


### PR DESCRIPTION
* Updated to jclouds 2.1.0
* added two parameters for diskSize and vpc network for GCE provider type

With the new changes, The GCE launcher will not create the network but instead it will use the vpc network supplied in the cluster definition, if the vpc network doesn't exist GCE Launcher will use the default network. If the supplied network and the default network don't exist, then the GCE launcher will throw an exception.