### PR TITLE
Added support for NVMe,HDD,SSD in GCE, and some other fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,11 @@ gce:
   vpc: default
   subnet: default
   diskSize: 15
+  nvme: 1
+  hdd: 1
+  ssd: 1
 ```
-<a href="https://cloud.google.com/compute/docs/machine-types">Machine type</a>, <a href="https://cloud.google.com/compute/docs/zones">zone of the VMs</a>, <a href="https://cloud.google.com/vpc/docs/vpc">VPC network</a>, <a href="https://cloud.google.com/compute/docs/images">VM image</a>, and the diskSize (in GB) can be specified by the user.
+<a href="https://cloud.google.com/compute/docs/machine-types">Machine type</a>, <a href="https://cloud.google.com/compute/docs/zones">zone of the VMs</a>, <a href="https://cloud.google.com/vpc/docs/vpc">VPC network</a>, <a href="https://cloud.google.com/compute/docs/images">VM image</a>, and the diskSize (in GB) can be specified by the user. A user can also specify the number of <a href="https://cloud.google.com/compute/docs/disks/">HDD, SSD, and NVMe </a> disks to be attached to the machine. The diskSize attribute specifies the diskSize for the boot disk and any HDD or SSD disks. The diskSize for the NVMe is 375 GB by default and cann't be changed.
 
 First of all, you need to enable Google Compute Engine API by going to the API Manager section in your Google Cloud Platform account. Karamel uses Compute Engine’s OAuth 2.0 authentication method. Therefore, an OAuth 2.0 client ID needs to be created through the Google’s Developer Console. The description on how to generate a client ID is available <a href="https://support.google.com/cloud/answer/6158849?hl=en">here</a>. You need to select _Service account_ as the application type. After generating a service account, click on _Generate new JSON key_ button to download a generated JSON file that contains both private and public keys. You need to register the fullpath of the generated JSON file with Karamel API.
 

--- a/karamel-common/src/main/java/se/kth/karamel/common/clusterdef/Gce.java
+++ b/karamel-common/src/main/java/se/kth/karamel/common/clusterdef/Gce.java
@@ -17,6 +17,9 @@ public class Gce extends Provider {
   private Long diskSize;
   private String subnet;
   private Boolean preemptible;
+  private Integer nvme;
+  private Integer hdd;
+  private Integer ssd;
   
   /**
    * Machine type.
@@ -127,6 +130,54 @@ public class Gce extends Provider {
     this.preemptible = preemptible;
   }
   
+  /**
+   * Number of NVMe disks (maximum 8)
+   * @return the number of NVMe disks.
+   */
+  public Integer getNvme() {
+    return nvme;
+  }
+  
+  /**
+   * Number of NVMe disks (maximum 8)
+   * @param nvme
+   */
+  public void setNvme(Integer nvme) {
+    this.nvme = nvme;
+  }
+  
+  /**
+   * Number of HDD disks.
+   * @return
+   */
+  public Integer getHdd() {
+    return hdd;
+  }
+  
+  /**
+   * Number of HDD disks.
+   * @param hdd
+   */
+  public void setHdd(Integer hdd) {
+    this.hdd = hdd;
+  }
+  
+  /**
+   * Number of SSD disks.
+   * @return
+   */
+  public Integer getSsd() {
+    return ssd;
+  }
+  
+  /**
+   * Number of SSD disks.
+   * @param ssd
+   */
+  public void setSsd(Integer ssd) {
+    this.ssd = ssd;
+  }
+  
   @Override
   public Gce cloneMe() {
     Gce gce = new Gce();
@@ -138,6 +189,9 @@ public class Gce extends Provider {
     gce.setDiskSize(this.diskSize);
     gce.setSubnet(this.subnet);
     gce.setPreemptible(this.preemptible);
+    gce.setNvme(this.nvme);
+    gce.setHdd(this.hdd);
+    gce.setSsd(this.ssd);
     return gce;
   }
 
@@ -170,6 +224,15 @@ public class Gce extends Provider {
       if(clone.isPreemptible() == null){
         clone.setPreemptible(parentGce.isPreemptible());
       }
+      if(clone.getNvme() == null){
+        clone.setNvme(parentGce.getNvme());
+      }
+      if(clone.getHdd() == null){
+        clone.setHdd(parentGce.getHdd());
+      }
+      if(clone.getSsd() == null){
+        clone.setSsd(parentGce.getSsd());
+      }
     }
     return clone;
   }
@@ -198,6 +261,15 @@ public class Gce extends Provider {
     if(clone.isPreemptible()== null){
       clone.setPreemptible(GceSettings.DEFAULT_IS_PRE_EMPTIBLE);
     }
+    if(clone.getNvme() == null){
+      clone.setNvme(GceSettings.DEFAULT_NUMBER_NVMe_DISKS);
+    }
+    if(clone.getHdd() == null){
+      clone.setHdd(GceSettings.DEFAULT_NUMBER_HDD_DISKS);
+    }
+    if(clone.getSsd() == null){
+      clone.setSsd(GceSettings.DEFAULT_NUMBER_SSD_DISKS);
+    }
     return clone;
   }
 
@@ -216,6 +288,9 @@ public class Gce extends Provider {
         ", diskSize=" + diskSize +
         ", subnet='" + subnet + '\'' +
         ", preemptible='" + preemptible + '\'' +
+        ", nvme=" + nvme +
+        ", hdd=" + hdd +
+        ", ssd=" + ssd +
         '}';
   }
 }

--- a/karamel-common/src/main/java/se/kth/karamel/common/util/GceSettings.java
+++ b/karamel-common/src/main/java/se/kth/karamel/common/util/GceSettings.java
@@ -17,6 +17,9 @@ public class GceSettings {
   public static final String DEFAULT_MACHINE_TYPE = MachineType.n1_standard_1.toString();
   public static final Long DEFAULT_DISKSIZE_IN_GB = 15l;
   public static final Boolean DEFAULT_IS_PRE_EMPTIBLE = false;
+  public static final Integer DEFAULT_NUMBER_NVMe_DISKS = 0;
+  public static final Integer DEFAULT_NUMBER_HDD_DISKS = 0;
+  public static final Integer DEFAULT_NUMBER_SSD_DISKS = 0;
   
   public enum MachineType {
 
@@ -120,4 +123,24 @@ public class GceSettings {
         projectName, imageName));
   }
   
+  public static URI buildLocalSSDDiskTypeUri(String projectName, String zone)
+      throws URISyntaxException {
+    return new URI(String.format("https://www.googleapis" +
+            ".com/compute/v1/projects/%s/zones/%s/diskTypes/local-ssd",
+        projectName, zone));
+  }
+  
+  public static URI buildSSDDiskTypeUri(String projectName, String zone)
+      throws URISyntaxException {
+    return new URI(String.format("https://www.googleapis" +
+            ".com/compute/v1/projects/%s/zones/%s/diskTypes/pd-ssd",
+        projectName, zone));
+  }
+  
+  public static URI buildHDDDiskTypeUri(String projectName, String zone)
+      throws URISyntaxException {
+    return new URI(String.format("https://www.googleapis" +
+            ".com/compute/v1/projects/%s/zones/%s/diskTypes/pd-standard",
+        projectName, zone));
+  }
 }

--- a/karamel-common/src/main/java/se/kth/karamel/common/util/Settings.java
+++ b/karamel-common/src/main/java/se/kth/karamel/common/util/Settings.java
@@ -252,6 +252,9 @@ public class Settings {
   public final static String REMOTE_CHEFJSON_PRIVATEIPS_TAG = "private_ips";
   public final static String REMOTE_CHEFJSON_PUBLICIPS_TAG = "public_ips";
   public final static String REMOTE_CHEFJSON_HOSTS_TAG = "hosts";
+  public final static String REMOTE_CHEFJSON_PRIVATEIPS_DOMAIN_IDS_TAG =
+      "private_ips_domainIds";
+  
   public static final String REMOTE_CHEFJSON_RUNLIST_TAG = "run_list";
   public static final String REMOTE_WORKING_DIR_NAME = ".karamel";
   public static final String REMOTE_INSTALL_DIR_NAME = "install";

--- a/karamel-core/src/main/java/se/kth/karamel/backend/running/model/ClusterRuntime.java
+++ b/karamel-core/src/main/java/se/kth/karamel/backend/running/model/ClusterRuntime.java
@@ -6,6 +6,8 @@
 package se.kth.karamel.backend.running.model;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -44,6 +46,23 @@ public class ClusterRuntime {
       GroupRuntime group = new GroupRuntime(this, jg);
       groups.add(group);
     }
+    Collections.sort(groups, new Comparator<GroupRuntime>() {
+      @Override
+      public int compare(GroupRuntime o1, GroupRuntime o2) {
+        String group1str = o1.getName().replaceAll("[0-9]", "").trim();
+        String group1number = o1.getName().replaceAll("[^0-9]", "").trim();
+        String group2str = o2.getName().replaceAll("[0-9]", "").trim();
+        String group2number = o2.getName().replaceAll("[^0-9]", "").trim();
+  
+        if (group1str.equalsIgnoreCase(group2str)) {
+          if(!group1number.isEmpty() && !group2number.isEmpty()) {
+            return Integer.compare(Integer.parseInt(group1number),
+                Integer.parseInt(group2number));
+          }
+        }
+        return group1str.compareTo(group2str);
+      }
+    });
   }
 
   public String getName() {

--- a/karamel-core/src/main/java/se/kth/karamel/backend/running/model/MachineRuntime.java
+++ b/karamel-core/src/main/java/se/kth/karamel/backend/running/model/MachineRuntime.java
@@ -26,6 +26,8 @@ public class MachineRuntime {
     ONGOING, FAILED, PAUSING, PAUSED, EMPTY
   }
 
+  public static final  int DEFAULT_LOCATION_DOMAIN_ID = 0;
+  
   private final GroupRuntime group;
   private LifeStatus lifeStatus = LifeStatus.FORKED;
   private TasksStatus tasksStatus = TasksStatus.EMPTY;
@@ -37,7 +39,8 @@ public class MachineRuntime {
   private String sshUser;
   private String machineType;
   private OsType osType;
-
+  private int locationDomainId = DEFAULT_LOCATION_DOMAIN_ID;
+  
   private final List<Task> tasks = new ArrayList<>();
 
   public MachineRuntime(GroupRuntime group) {
@@ -146,5 +149,14 @@ public class MachineRuntime {
   public String getId() {
     return publicIp;
   }
-
+  
+  
+  public int getLocationDomainId() {
+    return locationDomainId;
+  }
+  
+  public void setLocationDomainId(int locdomainId) {
+    this.locationDomainId = locdomainId;
+  }
+  
 }

--- a/karamel-ui/src/main/resources/assets/karamel/board/datamodel.js
+++ b/karamel-ui/src/main/resources/assets/karamel/board/datamodel.js
@@ -392,6 +392,9 @@ function Gce() {
   this.diskSize = null;
   this.subnet = null;
   this.preemptible = null;
+  this.nvme = null;
+  this.hdd = null;
+  this.ssd = null;
 
   this.load = function(other) {
     this.type = other.type || null;
@@ -402,6 +405,9 @@ function Gce() {
     this.diskSize = other.diskSize || null;
     this.subnet = other.subnet || null;
     this.preemptible = other.preemptible || null;
+    this.nvme = other.nvme || null;
+    this.hdd = other.hdd || null;
+    this.ssd = other.ssd || null;
   };
 
   this.copy = function(other) {
@@ -413,6 +419,9 @@ function Gce() {
     this.diskSize = other.diskSize || null;
     this.subnet = other.subnet || null;
     this.preemptible = other.preemptible || null;
+    this.nvme = other.nvme || null;
+    this.hdd = other.hdd || null;
+    this.ssd = other.ssd || null;
   };
 
   this.addAccountDetails = function(other) {
@@ -847,6 +856,10 @@ function toCoreApiFormat(uiCluster) {
     this.vpc = null;
     this.diskSize = null;
     this.subnet = null;
+    this.nvme = null;
+    this.hdd = null;
+    this.ssd = null;
+
     this.load = function(other) {
       this.type = other.type || null;
       this.zone = other.zone || null;
@@ -856,6 +869,9 @@ function toCoreApiFormat(uiCluster) {
       this.diskSize = other.diskSize || null;
       this.subnet = other.subnet || null;
       this.preemptible = other.preemptible || null;
+      this.nvme = other.nvme || null;
+      this.hdd = other.hdd || null;
+      this.ssd = other.ssd || null;
     }
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jclouds.version>2.1.0</jclouds.version>
+    <jclouds.version>2.1.2</jclouds.version>
     <java.compiler.version>1.8</java.compiler.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>


### PR DESCRIPTION
* Added support for attaching NVMe,HDD, SSD disks in GCE provider group
* Propagate LocationDomainIds (availability zones ids) in GCE to recipes
* Respect the same order for the groups as in the cluster definition
* Bump JClouds version to 2.1.2