### PR TITLE
[HOPSWORKS-1037][Karamel] Fixes to release Karamel 0.6

### DIFF
--- a/karamel-common/src/main/java/se/kth/karamel/common/util/Settings.java
+++ b/karamel-common/src/main/java/se/kth/karamel/common/util/Settings.java
@@ -103,7 +103,7 @@ public class Settings {
   }
 
   public static final String PREPARE_STORAGES_KEY = "karamel.prepare.storages";
-  public static final String PREPARE_STORAGES_DEFAULT = "false";
+  public static final String PREPARE_STORAGES_DEFAULT = "true";
   public static final String SKIP_EXISTINGTASKS_KEY = "karamel.skip.existing.tasks";
   public static final String SKIP_EXISTINGTASKS_DEFAULT = "false";
 

--- a/karamel-core/src/main/resources/se/kth/karamel/backend/shellscripts/prepare_storages.sh
+++ b/karamel-core/src/main/resources/se/kth/karamel/backend/shellscripts/prepare_storages.sh
@@ -1,5 +1,5 @@
 mkdir -p %install_dir_path% ; cd %install_dir_path%; echo $$ > %pid_file%; echo '#!/bin/bash
-
+symChef=0
 for i in %device_mountpoint_tuple% ; do 
 
 IFS=","
@@ -17,6 +17,11 @@ if [ -e $1 ]
       %sudo_command% mkfs -F -t ext4 $1
       %sudo_command% mkdir -p -m 777 $2
       %sudo_command% mount $1 $2
+      if [ "$symChef" -eq "0" ]; then
+        %sudo_command% mkdir -p -m 755 $2/.chef-solo
+        %sudo_command% ln -s $2/.chef-solo /tmp/chef-solo
+        symChef=1
+      fi
     fi
 
   else 

--- a/karamel-ui/deploy-packages-server.sh
+++ b/karamel-ui/deploy-packages-server.sh
@@ -1,12 +1,10 @@
 #!/bin/bash
-
 set -e
-
-if [ ! -d ../../karamel-examples ] ; then
+if [ ! -d ../../karamel-chef ] ; then
   echo ""
-  echo "You have to checkout git@github.com:karamelchef/karamel-examples.git in the parent folder for karamel to generate a distribution of karamel"
+  echo "You have to checkout git@github.com:logicalclocks/karamel-chef.git in the parent folder for karamel to generate a distribution of karamel"
   echo "cd ../../"
-  echo "git clone git@github.com:karamelchef/karamel-examples.git"
+  echo "git clone git@github.com:logicalclocks/karamel-chef.git"
   echo ""
   exit 1
 fi
@@ -20,7 +18,7 @@ dist=karamel-$version
 
 cd ..
 mvn clean package -DskipTests
-cd ../karamel-examples
+cd ../karamel-chef
 git pull
 cd ../karamel
 cd karamel-ui/target
@@ -29,9 +27,7 @@ cd karamel-ui/target
 cp -r appassembler/* $dist/
 cp ../README.linux $dist/README.txt
 mkdir $dist/examples
-cd ../../../karamel-examples
-git checkout-index -a -f --prefix=../karamel/karamel-ui/target/$dist/examples/
-cd ../karamel/karamel-ui/target
+cp ../../../karamel-chef/cluster-defns/* $dist/examples/
 tar zcf ${dist}.tgz $dist
 mv $dist ${dist}-linux
 
@@ -41,9 +37,7 @@ cp karamel-ui-${version}-shaded.jar ${dist}-jar/karamel-ui-${version}.jar
 cp -r appassembler/conf/* ${dist}-jar/
 cp ../README.linux ${dist}-jar/README.txt
 mkdir ${dist}-jar/examples
-cd ../../../karamel-examples
-git checkout-index -a -f --prefix=../karamel/karamel-ui/target/${dist}-jar/examples/
-cd ../karamel/karamel-ui/target
+cp ../../../karamel-chef/cluster-defns/* ${dist}-jar/examples/
 zip -r ${dist}-jar.zip $dist-jar
 
 scp ${dist}.tgz glassfish@snurran.sics.se:/var/www/karamel.io/sites/default/files/downloads/
@@ -58,9 +52,7 @@ mv karamel.exe $dist/karamel.exe
 #create windows archive
 cp ../README.windows $dist/README.txt
 mkdir $dist/examples
-cd ../../../karamel-examples
-git checkout-index -a -f --prefix=../karamel/karamel-ui/target/$dist/examples/
-cd ../karamel/karamel-ui/target
+cp ../../../karamel-chef/cluster-defns/* $dist/examples/
 zip -r ${dist}.zip $dist
 
 mv ${dist} ${dist}-windows


### PR DESCRIPTION
Jira: https://logicalclocks.atlassian.net/browse/HOPSWORKS-1307

* Enable prepare storage by default for EC2 instances
* add a symlink from /tmp/chefsolo to another dir in the mounted disk to avoid no space issues in the boot disk in EC2
* Use the cluster-defns in Karamel-chef as examples instead of karamel-examples