### PR TITLE
Increase karamel heap size

### DIFF
--- a/karamel-core/src/main/java/se/kth/karamel/backend/ClusterDefinitionService.java
+++ b/karamel-core/src/main/java/se/kth/karamel/backend/ClusterDefinitionService.java
@@ -9,6 +9,7 @@ import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.stream.JsonWriter;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
@@ -32,6 +33,8 @@ import se.kth.karamel.core.clusterdef.ClusterDefinitionValidator;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.Writer;
+import java.io.StringWriter;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -180,7 +183,12 @@ public class ClusterDefinitionService {
     GsonBuilder builder = new GsonBuilder();
     builder.disableHtmlEscaping();
     Gson gson = builder.setPrettyPrinting().create();
-    String json = gson.toJson(jsonCluster);
-    return json;
+    Writer result = new StringWriter();
+    try (JsonWriter writer = new JsonWriter(result)) {
+      gson.toJson(jsonCluster, jsonCluster.getClass(), writer);
+      return result.toString();
+    } catch (IOException ex) {
+      throw new KaramelException(ex);
+    }
   }
 }

--- a/karamel-ui/deploy-packages-server.sh
+++ b/karamel-ui/deploy-packages-server.sh
@@ -14,7 +14,7 @@ karamelize() {
     cd appassembler/bin
     head -n -9 karamel > karamel.tmp
     echo '
-exec "$JAVACMD" $JAVA_OPTS -Xms128m \
+exec "$JAVACMD" $JAVA_OPTS -Xms128m -Xmx4g \
   -classpath "$CLASSPATH" \
   -Dapp.name="karamel" \
   -Dapp.pid="$$" \

--- a/karamel-ui/pom.xml
+++ b/karamel-ui/pom.xml
@@ -272,6 +272,7 @@
               <configurationDirectory>conf</configurationDirectory>
               <copyConfigurationDirectory>true</copyConfigurationDirectory>
               <extraJvmArguments>-Xms128m</extraJvmArguments>
+              <extraJvmArguments>-Xmx4g</extraJvmArguments>
               <platforms>
                 <platform>unix</platform>
               </platforms>


### PR DESCRIPTION
Karamel runs out of heap size trying to serialize to JSON the full cluster definition.
Use streaming API of Gson but most importantly increase heap space