### PR TITLE
Remove unused dependencies

### DIFF
--- a/karamel-common/pom.xml
+++ b/karamel-common/pom.xml
@@ -21,6 +21,16 @@
       <groupId>org.apache.jclouds</groupId>
       <artifactId>jclouds-compute</artifactId>
       <version>${jclouds.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.ws.rs</groupId>
+          <artifactId>javax.ws.rs-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.inject</groupId>
+          <artifactId>javax.inject</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -51,11 +61,16 @@
       <groupId>org.apache.jclouds.driver</groupId>
       <artifactId>jclouds-sshj</artifactId>
       <version>${jclouds.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.jclouds.driver</groupId>
-      <artifactId>jclouds-enterprise</artifactId>
-      <version>${jclouds.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>net.java.dev.jna</groupId> 
+          <artifactId>jna</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>net.java.dev.jna</groupId>
+          <artifactId>jna-platform</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.jclouds.provider</groupId>


### PR DESCRIPTION
@SirOibaf Hi, I am a user of project **_se.kth.karamel:karamel-common:0.6_**. I found that its pom file introduced **_49_** dependencies. However, among them, **_9_** libraries (**_18%_**) have not been used by your project (the redundant dependencies are listed below). This PR helps **_se.kth.karamel:karamel-common:0.6_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
joda-time:joda-time:jar:2.1:compile
net.java.dev.jna:jna-platform:jar:4.1.0:compile
org.apache.jclouds.driver:jclouds-joda:jar:2.1.2:compile
io.netty:netty:jar:3.5.9.Final:compile
javax.inject:javax.inject:jar:1:compile
javax.ws.rs:javax.ws.rs-api:jar:2.0.1:compile
org.apache.jclouds.driver:jclouds-enterprise:jar:2.1.2:compile
net.java.dev.jna:jna:jar:4.1.0:compile
org.apache.jclouds.driver:jclouds-netty:jar:2.1.2:compile
</code></pre>